### PR TITLE
fix typo on title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# For Rails Begginer
+# For Rails Beginner
 
 給 Ruby on Rails 入門初學者
 


### PR DESCRIPTION
from `For Rails Begginer` to `For Rails Beginner`
